### PR TITLE
Update tests to not make strong assumptions about `actionButton()`'s HTML markup

### DIFF
--- a/tests/testthat/test-golem_utils_ui.R
+++ b/tests/testthat/test-golem_utils_ui.R
@@ -92,16 +92,9 @@ test_that("Test undisplay works", {
   )
 
   b <- shiny::actionButton("go_filter", "go")
-  expect_s3_class(b, "shiny.tag")
   expect_equal(
-    as.character(b),
-    '<button id="go_filter" type="button" class="btn btn-default action-button">go</button>'
-  )
-  b_undisplay <- undisplay(b)
-  expect_s3_class(b, "shiny.tag")
-  expect_equal(
-    as.character(b_undisplay),
-    '<button id="go_filter" type="button" class="btn btn-default action-button" style="display: none;">go</button>'
+    htmltools::tagGetAttribute(undisplay(b), "style"),
+    'display: none;'
   )
 })
 


### PR DESCRIPTION
Hello, I'm a core contributor to Shiny, and this PR is in anticipation for https://github.com/rstudio/shiny/pull/4249, where we plan on making changes to the HTML markup that `actionButton()` produces, which will break some of ShinySbm's tests running on CRAN.

I've updated your tests to still test the logic you're aiming to test, but without making such strong assumptions about the markup that `actionButton()` generates. If you could submit these changes to CRAN in the somewhat near future, that'd be greatly appreciated. Thanks!